### PR TITLE
Revert package.json back to main repo for litecore-lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bitcore-explorers",
+  "name": "litecore-explorers",
   "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -2703,7 +2703,9 @@
       }
     },
     "litecore-lib": {
-      "version": "github:majestic84/litecore-lib#c2296f4b1b40013c8267243ec06f6746aa7e3581",
+      "version": "0.13.22",
+      "resolved": "https://registry.npmjs.org/litecore-lib/-/litecore-lib-0.13.22.tgz",
+      "integrity": "sha1-fXQGvmdYLuX98qwABOpq0dHQ0/A=",
       "requires": {
         "bn.js": "2.0.4",
         "bs58": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "browser-request": "^0.3.3",
-    "litecore-lib": "github:majestic84/litecore-lib",
+    "litecore-lib": "^0.13.22",
     "request": "^2.51.0"
   }
 }


### PR DESCRIPTION
This PR changes the litecore-lib dependency back to the main repo rather than my own.