### PR TITLE
Change litecore-lib export alias from bitcore to litecore

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 module.exports = {
   models: require('./models'),
   Insight: require('./insight'),
-  bitcore: require('litecore-lib'),
+  litecore: require('litecore-lib'),
 };

--- a/lib/insight.js
+++ b/lib/insight.js
@@ -226,6 +226,30 @@ Insight.prototype.getBlocks = function(callback) {
 };
 
 /**
+ * @callback Insight.GetBlockIndexCallback
+ * @param {Error} err
+ * @param {string} blockhash
+ */
+
+/**
+ * Get block index
+ * @param {number} blockheight
+ * @param {GetBlockIndexCallback} callback
+ *  */
+Insight.prototype.getBlockIndex = function(blockheight, callback) {
+    $.checkArgument(_.isFunction(callback));
+
+    this.requestGet('/api/block-index/' + blockheight, function(err, res, body) {
+        if (err || res.statusCode !== 200) {
+            return callback(err || res);
+        }
+        let { blockHash } = JSON.parse(body);
+
+        return callback(null, blockHash);
+    });
+};
+
+/**
  * @callback Insight.GetBlockCallback
  * @param {Error} err
  * @param {Object} blocks


### PR DESCRIPTION
This allows one to use explorers.litecore rather than explorers.bitcore to reference litecore-lib methods.